### PR TITLE
商品詳細ページの実装

### DIFF
--- a/src/components/Product/ProductCard.tsx
+++ b/src/components/Product/ProductCard.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link";
+import Image from "next/image";
+import { Product } from "shopify-buy";
+
+type Props = {
+  product: Product;
+};
+
+const ProductCard = ({product}: Props) => {
+  return (
+    <>
+      <Link href={`product/${product.id}`}>
+        <a>
+          <Image
+            src={product.images[0].src}
+            alt={product.title}
+            width={300}
+            height={200}
+          />
+          <p>{product.title}</p>
+          <p>{product.description}</p>
+        </a>
+      </Link>
+    </>
+  );
+};
+
+export default ProductCard;

--- a/src/components/Product/ProductCard.tsx
+++ b/src/components/Product/ProductCard.tsx
@@ -9,15 +9,15 @@ type Props = {
 const ProductCard = ({product}: Props) => {
   return (
     <>
-      <Link href={`./products/${product.id}`}>
+      <Link href={`/products/${product.id}`}>
         <a>
+          <h1>{product.title}</h1>
           <Image
             src={product.images[0].src}
             alt={product.title}
             width={300}
             height={200}
           />
-          <p>{product.title}</p>
           <p>{product.description}</p>
         </a>
       </Link>

--- a/src/components/Product/ProductCard.tsx
+++ b/src/components/Product/ProductCard.tsx
@@ -9,7 +9,7 @@ type Props = {
 const ProductCard = ({product}: Props) => {
   return (
     <>
-      <Link href={`product/${product.id}`}>
+      <Link href={`./products/${product.id}`}>
         <a>
           <Image
             src={product.images[0].src}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import { GetServerSideProps } from 'next';
 import { Product } from 'shopify-buy';
 import Layout from '../components/Layout';
+import ProductCard from '../components/Product/ProductCard';
 import { useProducts } from '../hooks/products/use-products';
 
 type Props = {
@@ -11,14 +12,9 @@ const ProductList = ({ products }: Props) => {
   return (
     <Layout title="Home | Next.js + TypeScript Example">
       <h1>Product List</h1>
-      <ul>
         {products.map(p => 
-          <li key={p.id}>
-            {p.title}
-            <img src={p.images[0].src} height={80}></img>
-          </li>  
+          <ProductCard key={p.id} product={p}/>
         )}
-      </ul>
     </Layout>
   )
 };

--- a/src/pages/products/[id].tsx
+++ b/src/pages/products/[id].tsx
@@ -26,10 +26,19 @@ export const getStaticPaths: GetStaticPaths = async () => ({
 });
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
-  const product = await client.product.fetch(params?.id as string);
-  return {
-    props: {
-      product: JSON.parse(JSON.stringify(product)),
+  try {
+    const product = await client.product.fetch(params?.id as string);
+    if(!params) throw new Error('Product Not Found');
+    return {
+      props: {
+        product: JSON.parse(JSON.stringify(product)),
+      }
     }
+  } catch (error) {
+    return {
+      props: {
+        errors: error.message
+      }
+    };
   }
 }

--- a/src/pages/products/[id].tsx
+++ b/src/pages/products/[id].tsx
@@ -1,0 +1,13 @@
+import Link from "next/link";
+
+const ProductDetail = () => {
+  return (
+    <>
+      <h1>Hi</h1>
+      <Link href="/">
+        <a>Go Product List</a>
+      </Link>
+    </>
+  )
+}
+export default ProductDetail;

--- a/src/pages/products/[id].tsx
+++ b/src/pages/products/[id].tsx
@@ -1,13 +1,35 @@
+import { GetStaticPaths, GetStaticProps } from "next";
 import Link from "next/link";
+import { Product } from "shopify-buy";
+import ProductCard from "../../components/Product/ProductCard";
+import { client } from "../../shopify/client";
 
-const ProductDetail = () => {
+type Props = {
+  product: Product;
+};
+
+const ProductDetail = ({ product }: Props) => {
   return (
     <>
-      <h1>Hi</h1>
       <Link href="/">
-        <a>Go Product List</a>
+        <a>👈 Back to Product List</a>
       </Link>
+      <ProductCard product={product} />
     </>
   )
 }
 export default ProductDetail;
+
+export const getStaticPaths: GetStaticPaths = async () => ({
+  paths: [],
+  fallback: true,
+});
+
+export const getStaticProps: GetStaticProps = async ({ params }) => {
+  const product = await client.product.fetch(params?.id as string);
+  return {
+    props: {
+      product: JSON.parse(JSON.stringify(product)),
+    }
+  }
+}


### PR DESCRIPTION
## Set Images
To use relative urls for the `Image` src, I got to set an object in `next.config.js`.

documentation is[ here](https://nextjs.org/docs/basic-features/image-optimization)

## Path
If your pages have dynamic routes &&  use `getStaticProps`, then you need to use `getStaticPaths` to define the paths that are rendered to HTML at the build time.

In this case, product detail pages have dynamic routes defined by its product id.
Also I use `getStaticProps` to get products data.

documentation is [here](https://nextjs.org/docs/basic-features/data-fetching#getstaticpaths-static-generation)
 